### PR TITLE
Fix Version Script

### DIFF
--- a/scripts/tcframe
+++ b/scripts/tcframe
@@ -27,6 +27,12 @@ version() {
         exit 1
     fi
 
+    # Change to tcframe directory to ensure git command work correctly
+    cd "$TCFRAME_HOME" || {
+        echo "Error: Cannot access TCFRAME_HOME directory: $TCFRAME_HOME"
+        exit 1
+    }
+
     # Get the most recent tag and strip the 'v' prefix
     TAG=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
 


### PR DESCRIPTION
I found an issue with the "tcframe version" command when run it outside the tcframe folder (the git folder):

<img width="900" height="97" alt="Screen Shot 2025-08-07 at 21 40 50" src="https://github.com/user-attachments/assets/8ecdff70-5935-4e7a-9d07-eec02081ce05" />

In this PR, I try to solve that. And I checked, now it runs okay when it is executed outside the tcframe folder:

<img width="900" height="36" alt="Screen Shot 2025-08-07 at 21 41 03" src="https://github.com/user-attachments/assets/7ee6a278-34cf-4995-be04-2736e0f1c339" />
