### PR TITLE
fix: Use --strict for satisfies subtask but not assigned errors

### DIFF
--- a/include/tcframe/driver/Driver.hpp
+++ b/include/tcframe/driver/Driver.hpp
@@ -7,6 +7,7 @@
 #include "SlugParser.hpp"
 #include "SpecDriver.hpp"
 #include "TestCaseDriver.hpp"
+#include "tcframe/runner/core/Args.hpp"
 #include "tcframe/spec.hpp"
 
 using std::endl;
@@ -34,7 +35,7 @@ public:
             , testSpec_(testSpec) {}
 
     // TODO (fushar): In 2.0, replace this with entry point
-    virtual pair<SpecYaml, SpecDriver*> buildSpec() {
+    virtual pair<SpecYaml, SpecDriver*> buildSpec(const Args& args) {
         SpecYaml spec;
         spec.slug = SlugParser::parse(specPath_);
 
@@ -72,7 +73,8 @@ public:
                 new RawIOManipulator(),
                 new IOManipulator(ioFormat),
                 new Verifier(constraintSuite),
-                multipleTestCasesConfig);
+                multipleTestCasesConfig,
+                args);
 
         TestSuite testSuite = testSpec_->buildTestSuite(spec.slug, constraintSuite.getDefinedSubtaskIds());
         SeedSetter* seedSetter = testSpec_->buildSeedSetter();

--- a/include/tcframe/driver/TestCaseDriver.hpp
+++ b/include/tcframe/driver/TestCaseDriver.hpp
@@ -8,6 +8,7 @@
 
 #include "RawIOManipulator.hpp"
 #include "tcframe/exception.hpp"
+#include "tcframe/runner/core/Args.hpp"
 #include "tcframe/spec/config.hpp"
 #include "tcframe/spec/io.hpp"
 #include "tcframe/spec/testcase.hpp"
@@ -29,6 +30,7 @@ private:
     IOManipulator* ioManipulator_;
     Verifier* verifier_;
     MultipleTestCasesConfig multipleTestCasesConfig_;
+    const Args& args_;
 
 public:
     virtual ~TestCaseDriver() = default;
@@ -37,11 +39,13 @@ public:
             RawIOManipulator* rawIOManipulator,
             IOManipulator* ioManipulator,
             Verifier* verifier,
-            MultipleTestCasesConfig multipleTestCasesConfig)
+            MultipleTestCasesConfig multipleTestCasesConfig,
+            const Args& args)
             : ioManipulator_(ioManipulator)
             , rawIOManipulator_(rawIOManipulator)
             , verifier_(verifier)
-            , multipleTestCasesConfig_(move(multipleTestCasesConfig)) {}
+            , multipleTestCasesConfig_(move(multipleTestCasesConfig))
+            , args_(args) {}
 
     virtual void generateInput(const TestCase& testCase, ostream* out) {
         applyInput(testCase);
@@ -81,7 +85,7 @@ private:
 
     void verifyInput(const TestCase& testCase) {
         ConstraintsVerificationResult result = verifier_->verifyConstraints(testCase.subtaskIds());
-        if (!result.isValid()) {
+        if (!result.isValid(args_.strict())) {
             throw result.asFormattedError();
         }
     }

--- a/include/tcframe/runner/core/Args.hpp
+++ b/include/tcframe/runner/core/Args.hpp
@@ -30,6 +30,7 @@ private:
     optional<string> solution_;
     optional<int> timeLimit_;
     optional<string> output_;
+    bool strict_ = false;
 
 public:
     Command command() const {
@@ -74,6 +75,29 @@ public:
 
     const optional<int>& timeLimit() const {
         return timeLimit_;
+    }
+
+    bool strict() const {
+        return strict_;
+    }
+
+    void useStrict() {
+        strict_ = true;
+    }
+
+    bool operator==(const Args& o) const {
+        return command_ == o.command_
+            && brief_ == o.brief_
+            && communicator_ == o.communicator_
+            && memoryLimit_ == o.memoryLimit_
+            && noMemoryLimit_ == o.noMemoryLimit_
+            && noTimeLimit_ == o.noTimeLimit_
+            && scorer_ == o.scorer_
+            && seed_ == o.seed_
+            && solution_ == o.solution_
+            && timeLimit_ == o.timeLimit_
+            && output_ == o.output_
+            && strict_ == o.strict_;
     }
 };
 

--- a/include/tcframe/runner/core/ArgsParser.hpp
+++ b/include/tcframe/runner/core/ArgsParser.hpp
@@ -30,6 +30,7 @@ public:
                 { "seed",            required_argument, nullptr, 'h'},
                 { "solution",        required_argument, nullptr, 'i'},
                 { "time-limit",      required_argument, nullptr, 'j'},
+                { "strict",          no_argument,       nullptr, 'k'},
                 { 0, 0, 0, 0 }};
 
         Args args;
@@ -75,6 +76,9 @@ public:
                     break;
                 case 'j':
                     args.timeLimit_ = StringUtils::toNumber<int>(optarg);
+                    break;
+                case 'k':
+                    args.strict_ = true;
                     break;
                 case ':':
                     throw runtime_error("tcframe: option " + string(argv[optind - 1]) + " requires an argument");

--- a/include/tcframe/runner/core/Runner.hpp
+++ b/include/tcframe/runner/core/Runner.hpp
@@ -70,7 +70,7 @@ public:
 
         try {
             Args args = parseArgs(argc, argv);
-            pair<SpecYaml, SpecDriver*> spec = buildSpec(runnerLogger);
+            pair<SpecYaml, SpecDriver*> spec = buildSpec(runnerLogger, args);
             auto specClient = new SpecClient(spec.second, os_);
 
             int result;
@@ -96,9 +96,9 @@ private:
         }
     }
 
-    pair<SpecYaml, SpecDriver*> buildSpec(RunnerLogger* runnerLogger) {
+    pair<SpecYaml, SpecDriver*> buildSpec(RunnerLogger* runnerLogger, const Args& args) {
         try {
-            return driver_->buildSpec();
+            return driver_->buildSpec(args);
         } catch (runtime_error& e) {
             runnerLogger->logSpecificationFailure({e.what()});
             throw;

--- a/include/tcframe/spec/verifier/ConstraintsVerificationResult.hpp
+++ b/include/tcframe/spec/verifier/ConstraintsVerificationResult.hpp
@@ -34,9 +34,9 @@ public:
 
     ConstraintsVerificationResult() = default;
 
-    bool isValid() const {
+    bool isValid(bool strict) const {
         return unsatisfiedConstraintDescriptionsBySubtaskId_.empty() &&
-               satisfiedButNotAssignedSubtaskIds_.empty();
+               (!strict || satisfiedButNotAssignedSubtaskIds_.empty());
     }
 
     const map<int, vector<string>>& unsatisfiedConstraintDescriptionsBySubtaskId() const {

--- a/test/unit/tcframe/driver/MockDriver.hpp
+++ b/test/unit/tcframe/driver/MockDriver.hpp
@@ -12,7 +12,7 @@ public:
     MockDriver()
             : Driver<TProblemSpec>("", nullptr) {}
 
-    MOCK_METHOD0_T(buildSpec, pair<SpecYaml, SpecDriver*>());
+    MOCK_METHOD1_T(buildSpec, pair<SpecYaml, SpecDriver*>(const Args& args));
 };
 
 }

--- a/test/unit/tcframe/driver/MockTestCaseDriver.hpp
+++ b/test/unit/tcframe/driver/MockTestCaseDriver.hpp
@@ -3,13 +3,17 @@
 #include "gmock/gmock.h"
 
 #include "tcframe/driver/TestCaseDriver.hpp"
+#include "tcframe/runner/core/Args.hpp"
 
 namespace tcframe {
 
 class MockTestCaseDriver : public TestCaseDriver {
+private:
+    Args args_;
+
 public:
     MockTestCaseDriver()
-            : TestCaseDriver(nullptr, nullptr, nullptr, MultipleTestCasesConfig()) {}
+            : TestCaseDriver(nullptr, nullptr, nullptr, MultipleTestCasesConfig(), args_) {}
 
     MOCK_METHOD2(generateInput, void(const TestCase&, ostream*));
     MOCK_METHOD2(generateSampleOutput, void(const TestCase&, ostream*));

--- a/test/unit/tcframe/driver/TestCaseDriverTests.cpp
+++ b/test/unit/tcframe/driver/TestCaseDriverTests.cpp
@@ -9,6 +9,7 @@
 #include "../spec/io/MockIOManipulator.hpp"
 #include "../spec/verifier/MockVerifier.hpp"
 #include "tcframe/driver/TestCaseDriver.hpp"
+#include "tcframe/runner/core/Args.hpp"
 
 using ::testing::_;
 using ::testing::Eq;
@@ -34,6 +35,7 @@ protected:
     MOCK(RawIOManipulator) rawIOManipulator;
     MOCK(IOManipulator) ioManipulator;
     MOCK(Verifier) verifier;
+    Args args;
 
     TestCase sampleTestCase = TestCaseBuilder()
             .setName("foo_sample_1")
@@ -61,10 +63,11 @@ protected:
     TestCaseDriver driverWithMultipleTestCasesWithOutputPrefix = createDriver(multipleTestCasesConfigWithOutputPrefix);
 
     TestCaseDriver createDriver(MultipleTestCasesConfig multipleTestCasesConfig) {
-        return {&rawIOManipulator, &ioManipulator, &verifier, multipleTestCasesConfig};
+        return {&rawIOManipulator, &ioManipulator, &verifier, multipleTestCasesConfig, args};
     }
 
     void SetUp() {
+        args.useStrict();
         ON_CALL(verifier, verifyConstraints(_))
                 .WillByDefault(Return(ConstraintsVerificationResult()));
         ON_CALL(verifier, verifyMultipleTestCasesConstraints())

--- a/test/unit/tcframe/runner/core/RunnerTests.cpp
+++ b/test/unit/tcframe/runner/core/RunnerTests.cpp
@@ -56,7 +56,7 @@ TEST_F(RunnerTests, Run_Specification_Failed) {
     EXPECT_CALL(runnerLogger, logSpecificationFailure(vector<string>{"An error"}));
 
     MOCK(Driver<ProblemSpec>) driver;
-    ON_CALL(driver, buildSpec())
+    ON_CALL(driver, buildSpec(_))
             .WillByDefault(Throw(runtime_error("An error")));
 
     Runner<ProblemSpec> badRunner(

--- a/test/unit/tcframe/spec/verifier/VerifierTests.cpp
+++ b/test/unit/tcframe/spec/verifier/VerifierTests.cpp
@@ -64,7 +64,7 @@ bool VerifierTests::b5;
 TEST_F(VerifierTests, Verification_Valid_AllConstraintsValid) {
     ConstraintsVerificationResult result = verifier.verifyConstraints({Subtask::MAIN_ID});
 
-    EXPECT_TRUE(result.isValid());
+    EXPECT_TRUE(result.isValid(true));
     EXPECT_THAT(result.satisfiedButNotAssignedSubtaskIds(), IsEmpty());
     EXPECT_THAT(result.unsatisfiedConstraintDescriptionsBySubtaskId(), IsEmpty());
 }
@@ -73,7 +73,7 @@ TEST_F(VerifierTests, Verification_Invalid_SomeConstraintsInvalid) {
     b2 = false;
     ConstraintsVerificationResult result = verifier.verifyConstraints({Subtask::MAIN_ID});
 
-    EXPECT_FALSE(result.isValid());
+    EXPECT_FALSE(result.isValid(true));
     EXPECT_THAT(result.satisfiedButNotAssignedSubtaskIds(), IsEmpty());
     EXPECT_THAT(result.unsatisfiedConstraintDescriptionsBySubtaskId(), ElementsAre(
             Pair(Subtask::MAIN_ID, ElementsAre("1 <= B && B <= 10"))));
@@ -82,7 +82,7 @@ TEST_F(VerifierTests, Verification_Invalid_SomeConstraintsInvalid) {
 TEST_F(VerifierTests, Verification_WithSubtasks_Valid_AllConstraintsValid) {
     ConstraintsVerificationResult result = verifierWithSubtasks.verifyConstraints({1, 2, 3});
 
-    EXPECT_TRUE(result.isValid());
+    EXPECT_TRUE(result.isValid(true));
     EXPECT_THAT(result.satisfiedButNotAssignedSubtaskIds(), IsEmpty());
     EXPECT_THAT(result.unsatisfiedConstraintDescriptionsBySubtaskId(), IsEmpty());
 }
@@ -91,7 +91,7 @@ TEST_F(VerifierTests, Verification_WithSubtasks_Valid_AllAssignedSubtasksValid) 
     b4 = false;
     ConstraintsVerificationResult result = verifierWithSubtasks.verifyConstraints({1, 3});
 
-    EXPECT_TRUE(result.isValid());
+    EXPECT_TRUE(result.isValid(true));
     EXPECT_THAT(result.satisfiedButNotAssignedSubtaskIds(), IsEmpty());
     EXPECT_THAT(result.unsatisfiedConstraintDescriptionsBySubtaskId(), IsEmpty());
 }
@@ -100,7 +100,7 @@ TEST_F(VerifierTests, Verification_WithSubtasks_Invalid_SomeConstraintsInvalid) 
     b4 = false;
     ConstraintsVerificationResult result = verifierWithSubtasks.verifyConstraints({2, 3});
 
-    EXPECT_FALSE(result.isValid());
+    EXPECT_FALSE(result.isValid(true));
     EXPECT_THAT(result.satisfiedButNotAssignedSubtaskIds(), ElementsAre(1));
     EXPECT_THAT(result.unsatisfiedConstraintDescriptionsBySubtaskId(), ElementsAre(
             Pair(2, ElementsAre("1 <= D && D <= 10"))));
@@ -109,7 +109,7 @@ TEST_F(VerifierTests, Verification_WithSubtasks_Invalid_SomeConstraintsInvalid) 
 TEST_F(VerifierTests, Verification_WithConstraintsAndSubtasks_Valid_AllConstraintsValid) {
     ConstraintsVerificationResult result = verifierWithConstraintsAndSubtasks.verifyConstraints({1, 2});
 
-    EXPECT_TRUE(result.isValid());
+    EXPECT_TRUE(result.isValid(true));
     EXPECT_THAT(result.satisfiedButNotAssignedSubtaskIds(), IsEmpty());
     EXPECT_THAT(result.unsatisfiedConstraintDescriptionsBySubtaskId(), IsEmpty());
 }
@@ -118,7 +118,7 @@ TEST_F(VerifierTests, Verification_WithConstraintsAndSubtasks_Valid_AllAssignedS
     b1 = false;
     ConstraintsVerificationResult result = verifierWithConstraintsAndSubtasks.verifyConstraints({2});
 
-    EXPECT_TRUE(result.isValid());
+    EXPECT_TRUE(result.isValid(true));
     EXPECT_THAT(result.satisfiedButNotAssignedSubtaskIds(), IsEmpty());
     EXPECT_THAT(result.unsatisfiedConstraintDescriptionsBySubtaskId(), IsEmpty());
 }
@@ -127,7 +127,7 @@ TEST_F(VerifierTests, Verification_WithConstraintsAndSubtasks_Invalid_SomeConstr
     b4 = false;
     ConstraintsVerificationResult result = verifierWithConstraintsAndSubtasks.verifyConstraints({2});
 
-    EXPECT_FALSE(result.isValid());
+    EXPECT_FALSE(result.isValid(true));
     EXPECT_THAT(result.satisfiedButNotAssignedSubtaskIds(), ElementsAre(1));
     EXPECT_THAT(result.unsatisfiedConstraintDescriptionsBySubtaskId(), ElementsAre(
             Pair(2, ElementsAre("1 <= D && D <= 10"))));
@@ -137,7 +137,7 @@ TEST_F(VerifierTests, Verification_WithConstraintsAndSubtasks_Invalid_GlobalCons
     b0 = false;
     ConstraintsVerificationResult result = verifierWithConstraintsAndSubtasks.verifyConstraints({1, 2});
 
-    EXPECT_FALSE(result.isValid());
+    EXPECT_FALSE(result.isValid(true));
     EXPECT_THAT(result.satisfiedButNotAssignedSubtaskIds(), IsEmpty());
     EXPECT_THAT(result.unsatisfiedConstraintDescriptionsBySubtaskId(), ElementsAre(
             Pair(Subtask::MAIN_ID, ElementsAre("1 <= X && X <= 10"))));


### PR DESCRIPTION
Remove errors like the following:

```
M_2_5: FAILED
    Description: T=1, r=2, c=5, A={{1LL,3LL,5LL,7LL,9LL},{9LL,7LL,5LL,3LL,1LL}}, d={10LL, 8LL, 6LL, 4LL, 2LL}
    Reasons:
    * Satisfies subtask 1 but is not assigned to it
  M_2_6: FAILED
    Description: T=1, r=5, c=2, A={{1LL,9LL},{3LL,7LL},{5LL,5LL},{7LL,3LL},{9LL,1LL}}, d={2LL, 2LL}
    Reasons:
    * Satisfies subtask 1 but is not assigned to it
```

if `--strict` is not passed

Issue: https://github.com/ia-toki/tcframe/issues/166

@fushar @jonathanirvings (original issue)